### PR TITLE
Fix upload-artifact to v3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@main
+        uses: actions/upload-artifact@v3
         with:
           name: bottles
           path: '*.bottle.*'


### PR DESCRIPTION
Due to breaking changes in v4,
it is no longer possible to
upload to the same named artifact
multiple times. On v4, we encounter
this error due to running multiple
versions of Ubuntu and MacOS.
https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes