### PR TITLE
coveralls 0.6.15

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, macos-12, macos-13]
+        os: [ubuntu-20.04, ubuntu-22.04, macos-13, macos-latest]
     runs-on: ${{ matrix.os }}
     env:
       HOMEBREW_NO_INSTALL_FROM_API: 1

--- a/Formula/coveralls.rb
+++ b/Formula/coveralls.rb
@@ -1,8 +1,8 @@
 class Coveralls < Formula
   desc "Self-contained, universal coverage uploader for Coveralls"
   homepage "https://github.com/coverallsapp/coverage-reporter"
-  url "https://github.com/coverallsapp/coverage-reporter/archive/refs/tags/v0.6.14.tar.gz"
-  sha256 "32ddfdd3d6b9001ccf394d9679c919f506eb35cb83dcba8fd17ba2c898bff027"
+  url "https://github.com/coverallsapp/coverage-reporter/archive/refs/tags/v0.6.15.tar.gz"
+  sha256 "b29d4b2c61ebce695c35077099da3a53b72c1280f77da4a220288ff306508e79"
   license "MIT"
 
   bottle do


### PR DESCRIPTION
Manually created PR after experiencing issues with standard process using [`action-homebrew-bump-formula`](https://github.com/dawidd6/action-homebrew-bump-formula).

- [x] Update formula to 0.6.15 and added missing dependencies. 
- [x] Drop support for `macos-12` after receiving back this message from Homebrew: "_Warning: You are using macOS 12. We (and Apple) do not provide support for this old version. It is expected behaviour that some formulae will fail to build in this old version._"