### PR TITLE
README: update install instructions for Homebrew 6.0.0 tap trust

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,17 @@ This homebrew tap provides the following package:
 ## Installation
 
 ```bash
-brew tap coverallsapp/coveralls
-brew install coveralls
+brew install coverallsapp/coveralls/coveralls
 ```
 
-Or
+The fully-qualified name taps this repo automatically and trusts only the `coveralls` formula, as required by [tap trust](https://docs.brew.sh/Tap-Trust) in Homebrew 6.0.0+.
+
+Alternatively, trust the whole tap first:
 
 ```bash
-brew install coverallsapp/coveralls/coveralls
+brew trust coverallsapp/coveralls   # Homebrew 6.0.0+
+brew tap coverallsapp/coveralls
+brew install coveralls
 ```
 
 ## Updating the formula (dev)


### PR DESCRIPTION
Homebrew 6.0.0 ([released 2026-06-11](https://brew.sh/2026/06/11/homebrew-6.0.0/)) requires third-party taps to be explicitly trusted before their formulae load ([Tap Trust docs](https://docs.brew.sh/Tap-Trust)), so the previous primary instructions:

```bash
brew tap coverallsapp/coveralls
brew install coveralls
```

now fail with:

```
Error: Refusing to load formula coverallsapp/coveralls/coveralls from untrusted tap coverallsapp/coveralls.
```

This PR makes the fully-qualified one-liner the primary instruction:

```bash
brew install coverallsapp/coveralls/coveralls
```

It auto-taps this repo, trusts only the `coveralls` formula (non-interactively), and works identically on Homebrew < 6. The tap-then-install flow is kept as an alternative, now prefixed with `brew trust coverallsapp/coveralls`.

Companion to coverallsapp/github-action#265, which fixes the same break in the GitHub Action (coverallsapp/github-action#264).

🤖 Generated with [Claude Code](https://claude.com/claude-code)