### PR TITLE
CI: drop ubuntu-22.04 from the test-bot matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-latest]
+        os: [ubuntu-24.04, macos-14, macos-latest]
     runs-on: ${{ matrix.os }}
     env:
       HOMEBREW_NO_INSTALL_FROM_API: 1


### PR DESCRIPTION
Homebrew now classifies Ubuntu 22.04 (glibc 2.35) as a [Tier 2 platform](https://docs.brew.sh/Support-Tiers#tier-2), so `brew doctor` fails `test-bot --only-setup` deterministically on that runner — every PR to this tap shows a red `ubuntu-22.04` leg regardless of content (verified failing identically six weeks apart, 2026-06-11 and 2026-07-27, e.g. [this run](https://github.com/coverallsapp/homebrew-coveralls/actions/runs/30285000036)).

Dropping the leg:
- `ubuntu-24.04` continues to build the `x86_64_linux` bottle (passing).
- Side effect: with the always-red leg gone, `fail-fast` no longer cancels `macos-14` — this PR's CI will show that leg's true current status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)