### PR TITLE
coveralls 0.6.18

### DIFF
--- a/Formula/coveralls.rb
+++ b/Formula/coveralls.rb
@@ -21,7 +21,10 @@ class Coveralls < Formula
   depends_on "sqlite"
 
   uses_from_macos "libxml2"
-  uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "zlib-ng-compat"
+  end
 
   def install
     system "shards", "build", "coveralls", "--production", "--release", "--no-debug"

--- a/Formula/coveralls.rb
+++ b/Formula/coveralls.rb
@@ -1,8 +1,8 @@
 class Coveralls < Formula
   desc "Self-contained, universal coverage uploader for Coveralls"
   homepage "https://github.com/coverallsapp/coverage-reporter"
-  url "https://github.com/coverallsapp/coverage-reporter/archive/refs/tags/v0.6.17.tar.gz"
-  sha256 "24b4e10efb0be269b924877860bfd673588b3ab7f1e8dcf36257db332a6853a9"
+  url "https://github.com/coverallsapp/coverage-reporter/archive/refs/tags/v0.6.18.tar.gz"
+  sha256 "155ab95b991d8532b80a21428cea195540be5a8fc389010ce507d4311b80b372"
   license "MIT"
 
   bottle do

--- a/Formula/coveralls.rb
+++ b/Formula/coveralls.rb
@@ -16,10 +16,12 @@ class Coveralls < Formula
   depends_on "bdw-gc"
   depends_on "libevent"
   depends_on "libyaml"
+  depends_on "openssl@3"
   depends_on "pcre2"
   depends_on "sqlite"
 
   uses_from_macos "libxml2"
+  uses_from_macos "zlib"
 
   def install
     system "shards", "build", "coveralls", "--production", "--release", "--no-debug"


### PR DESCRIPTION
Bumps `coveralls` to [v0.6.18](https://github.com/coverallsapp/coverage-reporter/releases/tag/v0.6.18).

## Why this is a manual bump

The automated `homebrew` job in `coverage-reporter`'s `build.yml` failed on the v0.6.18 release:

```
Refusing to load formula coverallsapp/coveralls/coveralls from untrusted tap
coverallsapp/coveralls. (Homebrew::UntrustedTapError)
```

Homebrew 6.0.0+ requires taps to be explicitly trusted, and that job was pinned to `dawidd6/action-homebrew-bump-formula@v3`, which predates the requirement and never calls `brew trust`. The action upgrade (v3 → v8) is in coverallsapp/coverage-reporter#194, but merging it cannot retroactively fix the existing `v0.6.18` tag — a workflow re-run uses the workflow file from the tagged commit, which still contains `@v3`. Hence this manual bump.

## What's in v0.6.18

Fixes the simplecov parser crashing on float timestamps, which broke coverage upload entirely for anyone on SimpleCov v1.1.0+ (coverallsapp/github-action#269).

## Verification

`sha256` verified against a fresh download of the source tarball:

```
155ab95b991d8532b80a21428cea195540be5a8fc389010ce507d4311b80b372
```

Confirmed the tarball contains `version: 0.6.18`, `VERSION = "0.6.18"`, and the fix itself (`property timestamp : Int64 | Float64 | Nil`).

Changes `url` and `sha256` only, matching the shape of the previous bump (bb84f9b6). The `bottle` block is left for `brew pr-pull` to update.

**Label this `pr-pull` once test-bot is green** to build and publish the bottles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)