### PR TITLE
CI: pin Homebrew/actions refs and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# Dependabot keeps this tap's CI dependencies from silently drifting.
+#
+# Context: the coverage-reporter v0.6.18 release surfaced three separate
+# breakages caused by external drift in release infrastructure that had not
+# run since Sept 2025 -- one of which was a GitHub Action pinned five major
+# versions behind. This tap is part of that same release path, so it gets the
+# same protection.
+#
+# The Homebrew/actions refs are pinned to a SHA with a trailing version
+# comment; Dependabot reads that comment and will open PRs to advance both the
+# SHA and the comment as new releases are tagged.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,10 +11,10 @@ jobs:
       HOMEBREW_NO_INSTALL_FROM_API: 1
     steps:
       - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@b35a29a0f83ee8b8ca07b219fc8db3d7bb88ab49 # 2026.08.10.2
 
       - name: Set up git
-        uses: Homebrew/actions/git-user-config@master
+        uses: Homebrew/actions/git-user-config@b35a29a0f83ee8b8ca07b219fc8db3d7bb88ab49 # 2026.08.10.2
 
       - name: Pull bottles
         env:
@@ -25,7 +25,7 @@ jobs:
         run: brew pr-pull --debug --tap="$GITHUB_REPOSITORY" "$PULL_REQUEST"
 
       - name: Push commits
-        uses: Homebrew/actions/git-try-push@master
+        uses: Homebrew/actions/git-try-push@b35a29a0f83ee8b8ca07b219fc8db3d7bb88ab49 # 2026.08.10.2
         with:
           token: ${{ secrets.HOMEBREW_TOKEN }}
           branch: main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@b35a29a0f83ee8b8ca07b219fc8db3d7bb88ab49 # 2026.08.10.2
 
       - name: Cache Homebrew Bundler RubyGems
         id: cache


### PR DESCRIPTION
## Problem

Every CI run on this tap emits:

```
Homebrew/actions/setup-homebrew@master is deprecated. Please update your
workflow references to pin Homebrew/actions/setup-homebrew@<sha>.
The "master" branch sync will stop and this warning will become an error
when Homebrew 5.2.0 is released (no earlier than 2026-06-10).
```

**Homebrew is already at 6.0.17** — well past the 5.2.0 cutoff that message names — and it's *still* only a warning. So the stated timeline is stale and the real enforcement date is unpredictable. This is a queued breakage in the coverage-reporter release path with no reliable deadline, which is a good reason to fix it now rather than discover it during a release.

**No Homebrew upgrade is required.** The deprecation is only that the `master` branch will stop being synced; pinning to a tag/SHA sidesteps it entirely.

## Changes

**1. Pin all four `Homebrew/actions` refs** from `@master` to the SHA for tag `2026.08.10.2`:

| File | Action |
|---|---|
| `tests.yml:18` | `setup-homebrew` |
| `publish.yml:14` | `setup-homebrew` |
| `publish.yml:17` | `git-user-config` |
| `publish.yml:28` | `git-try-push` |

SHA verified against the upstream tag ref:

```
$ gh api repos/Homebrew/actions/git/ref/tags/2026.08.10.2 --jq '.object.sha'
b35a29a0f83ee8b8ca07b219fc8db3d7bb88ab49
```

Pinning third-party actions to a SHA is also the recommended supply-chain practice.

**2. Add Dependabot** for the `github-actions` ecosystem, weekly, capped at 5 open PRs.

The trailing `# 2026.08.10.2` version comments are what let Dependabot advance both the SHA *and* the comment as new releases are tagged — so pinning doesn't mean going stale again. That combination is the point: pinned for reproducibility and supply-chain safety, but actively maintained.

## Why now

The coverage-reporter v0.6.18 release surfaced **three** separate breakages, all from external drift in infrastructure that hadn't run since Sept 2025:

1. Homebrew's formula index gained entries with no `stable` bottle → broke the xbuild container (coverallsapp/coverage-reporter#192)
2. Homebrew 6.0.0 introduced tap trust, with the bump action pinned five majors behind → broke the formula bump (coverallsapp/coverage-reporter#194)
3. Homebrew changed the Linux zlib provider and tightened `brew linkage` → broke this formula (#74)

This tap is part of that same release path. Dependabot on `coverage-reporter` landed in coverallsapp/coverage-reporter#195; this is the matching change here.

## Note on testing

`brew test-bot --only-formulae` only builds formulae that changed in the diff, and this PR touches no formula — so CI here exercises the pinned `setup-homebrew` through the setup and tap-syntax steps, but won't rebuild the formula. That's the expected coverage for a CI-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
